### PR TITLE
initramfs: call init.cryptfs to mount LUKS partition

### DIFF
--- a/meta-cube/recipes-core/initrdscripts/files/init-server.sh
+++ b/meta-cube/recipes-core/initrdscripts/files/init-server.sh
@@ -86,9 +86,20 @@ mkdir -p $ROOT_MOUNT/
 
 sleep ${ROOT_DELAY}
 
+try_to_mount_rootfs() {
+    local mount_flags="rw,noatime"
+
+    mount -o $mount_flags "${ROOT_DEVICE}" "${ROOT_MOUNT}" 2>/dev/null && return 0
+
+    [ -x /init.cryptfs ] &&
+        /init.cryptfs "${ROOT_MOUNT}" "${ROOT_DEVICE}" $mount_flags "OVERCROOTFS" && return 0
+
+    return 1
+}
+
 echo "Waiting for root device to be ready..."
 while [ 1 ] ; do
-    mount -o rw,noatime $ROOT_DEVICE $ROOT_MOUNT && break
+    try_to_mount_rootfs && break
     sleep 0.1
 done
 


### PR DESCRIPTION
Note that this feature is for pulsar-8 only so this commit is submitted to pulsar-8 branch not master.

If the normal mount operation failes, it may be caused by the LUKS
partition is used as rootfs. Hence, an opportunity is given to
launch init.cryptfs.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>