### PR TITLE
initramfs: call the signed switch_root in the real rootfs

### DIFF
--- a/meta-cube/recipes-core/lxc/lxc_%.bbappend
+++ b/meta-cube/recipes-core/lxc/lxc_%.bbappend
@@ -28,7 +28,7 @@ do_install_append(){
 	sed -i 's/lxc-net.service//g'  ${D}${systemd_unitdir}/system/lxc.service
 	sed -i 's/\(After=.*$\)/\1 openvswitch.service/' ${D}${systemd_unitdir}/system/lxc.service
 	sed -i '1,/ExecStartPre/ {/ExecStartPre/ i\
-ExecStartPre=/etc/lxc/lxc-overlayscan\nExecStartPre=/etc/lxc/lxc-overlayrestore
+ExecStartPre=sh -c "/etc/lxc/lxc-overlayscan"\nExecStartPre=sh -c "/etc/lxc/lxc-overlayrestore"
 }' ${D}${systemd_unitdir}/system/lxc.service
 
 	# disable the dmesg output on the console when booting the containers,


### PR DESCRIPTION
Instead of running switch_root directly from initramfs, a statically
linked switch_root from the real rootfs is called and it must be already
signed properly. Otherwise, switch_root will fail to mount the real
rootfs and kernel panic will happen due to this failure.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>