### PR TITLE
go: fix more build failures due to GOROOT

### DIFF
--- a/meta-cube/recipes-connectivity/consul/consul-migrate_git.bb
+++ b/meta-cube/recipes-connectivity/consul/consul-migrate_git.bb
@@ -13,6 +13,8 @@ inherit golang
 
 SYSROOT_PREPROCESS_FUNCS += "consul_migrate_sysroot_preprocess"
 
+export GOROOT="${STAGING_DIR_NATIVE}/${nonarch_libdir}/${HOST_SYS}/go"
+
 consul_migrate_sysroot_preprocess () {
     install -d ${SYSROOT_DESTDIR}${prefix}/local/go/src/${PKG_NAME}
     cp -a ${D}${prefix}/local/go/src/${PKG_NAME} ${SYSROOT_DESTDIR}${prefix}/local/go/src/$(dirname ${PKG_NAME})

--- a/meta-cube/recipes-connectivity/consul/consul_git.bb
+++ b/meta-cube/recipes-connectivity/consul/consul_git.bb
@@ -54,6 +54,8 @@ WARN_QA_append = " ldflags"
 SYSTEMD_SERVICE_${PN} = "consul.service"
 SYSTEMD_AUTO_ENABLE_${PN} = "enable"
 
+export GOROOT="${STAGING_DIR_NATIVE}/${nonarch_libdir}/${HOST_SYS}/go"
+
 #Stops go from installing and testing the package
 do_configure(){
 }

--- a/meta-cube/recipes-connectivity/etcd/etcd_git.bb
+++ b/meta-cube/recipes-connectivity/etcd/etcd_git.bb
@@ -21,3 +21,5 @@ inherit golang
 INSANE_SKIP_${PN} = "ldflags"
 
 RDEPENDS_${PN} = "bash"
+
+export GOROOT="${STAGING_DIR_NATIVE}/${nonarch_libdir}/${HOST_SYS}/go"

--- a/meta-cube/recipes-devtools/go/hashicorp-hcl_git.bb
+++ b/meta-cube/recipes-devtools/go/hashicorp-hcl_git.bb
@@ -12,6 +12,8 @@ S = "${WORKDIR}/git"
 inherit golang
 
 do_compile() {
+    export GOROOT="${STAGING_DIR_NATIVE}/${nonarch_libdir}/${HOST_SYS}/go"
+
     oe_runmake generate
 }
 


### PR DESCRIPTION
This fix resolves the build failures for more recipes.

- consul
- consul-migrate
- etcd
- hashicorp-hcl

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>