### PR TITLE
cube-builder-initramfs: define CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL

### DIFF
--- a/meta-cube/recipes-core/images/cube-builder-initramfs.bb
+++ b/meta-cube/recipes-core/images/cube-builder-initramfs.bb
@@ -3,10 +3,16 @@ DESCRIPTION = "Small image capable of booting a device. The kernel includes \
 the Minimal RAM-based Initial Root Filesystem (initramfs), which finds the \
 first 'init' program more efficiently."
 
+CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL ?= ""
+
 # Archived variant for running a full installer from the initramfs
 # PACKAGE_INSTALL = "initramfs-cube-builder bash kmod bzip2 vim which sed tar kbd coreutils util-linux grep gawk udev mdadm base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
 PACKAGE_INSTALL = "initramfs-cube-builder bash kmod bzip2 sed tar kbd coreutils util-linux grep gawk udev mdadm base-passwd ${ROOTFS_BOOTSTRAP_INSTALL}"
 PACKAGE_EXCLUDE = "busybox busybox-dev busybox-udhcpc busybox-dbg busybox-ptest busybox-udhcpd busybox-hwclock busybox-syslog"
+
+IMAGE_INSTALL += " \
+                  ${CUBE_BUILDER_INITRAMFS_EXTRA_INSTALL} \
+                 "
 
 # Do not pollute the initrd image with rootfs features
 IMAGE_FEATURES = ""


### PR DESCRIPTION
Like to other images, cube-builder-initramfs requires such a variable to
allow to add extra packages.

This commit has been merged to the master branch.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>