### PR TITLE
meta-overc: run the shell script in bash command

### DIFF
--- a/meta-cube/recipes-support/overc-conftools/source/network_prime/files/overc-network-prime-port-forward.service
+++ b/meta-cube/recipes-support/overc-conftools/source/network_prime/files/overc-network-prime-port-forward.service
@@ -4,7 +4,7 @@ After=systemd-networkd.service
 
 [Service]
 Type=oneshot
-ExecStart=/etc/overc/network_prime_port_forward.sh
+ExecStart=/bin/bash /etc/overc/network_prime_port_forward.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-cube/recipes-support/overc-conftools/source/network_prime/files/overc-network-prime.service
+++ b/meta-cube/recipes-support/overc-conftools/source/network_prime/files/overc-network-prime.service
@@ -5,7 +5,7 @@ Before=systemd-networkd.service
 
 [Service]
 Type=oneshot
-ExecStart=/etc/overc/network_prime.sh
+ExecStart=/bin/bash /etc/overc/network_prime.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When IMA feature is enabled, run the script directly will be
denied, thus run it in bash will fix this issue.

Signed-off-by: fli <fupan.li@windriver.com>