### PR TITLE
Fix order of arguments for container entrypoint

### DIFF
--- a/meta-cube/recipes-support/overc-utils/source/cube-cfg
+++ b/meta-cube/recipes-support/overc-utils/source/cube-cfg
@@ -694,7 +694,7 @@ generate_base_config()
     app=$(cat cube.app${var_extension})
     app_args=""
     for a in ${app}; do
-	app_args="--args $a $app_args"
+	app_args="$app_args --args $a"
     done
 
     OLDIFS=$IFS


### PR DESCRIPTION
The arguments for the container entrypoint need to be appended
rather than prepended.  Otherwise they get reversed in config.json
and the container fails to start.

Signed-off-by: Rob Woolley <rob.woolley@windriver.com>