### PR TITLE
ostree: fix a parallel compilation issue

### DIFF
--- a/meta-cube/recipes-support/ostree/ostree_git.bb
+++ b/meta-cube/recipes-support/ostree/ostree_git.bb
@@ -14,7 +14,7 @@ SRCREV = "ae61321046ad7f4148a5884c8c6c8b2594ff840e"
 PV = "2017.13+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-inherit autotools pkgconfig systemd gobject-introspection
+inherit autotools-brokensep pkgconfig systemd gobject-introspection
 
 DEPENDS = " \
     glib-2.0 libsoup-2.4 gpgme e2fsprogs \


### PR DESCRIPTION
A regression was introduced by commit 7a464681:

    ostree: update to 2017.13

    To fix compilation issues, we update to 2017.13 and keep in sync
    with meta-updater's version.

it reverted a following commit 7b436f86:

    ostree: inherit autotools-brokensep instead of autotools

    Autotools class for ostree recipe where separates build dir doesn't
    work well, we have observed quite a few parellel compilation issues, so
    we change it to inherit autotools-brokensep instead, which probably can
    fix those issues, and this is also how autotools is being used in
    ostree recipe of meta-updater project.

this lead ostree fail on parallel compilation again, add it back.

Signed-off-by: Ming Liu <liu.ming50@gmail.com>